### PR TITLE
依存ライブラリの更新

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.3.0.RELEASE"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.3.1.RELEASE"
     }
 }
 
 apply plugin: "scala"
 apply plugin: "spring-boot"
 
-version = "0.2.0"
+version = "0.2.1"
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
@@ -37,8 +37,8 @@ dependencies {
     compile "org.scala-lang:scala-library:2.11.7"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.6.+"
     compile "com.fasterxml.jackson.module:jackson-module-scala_2.11:2.6.+"
-    compile "org.scalikejdbc:scalikejdbc-jsr310_2.11:2.2.9"
-    compile "org.skinny-framework:skinny-orm_2.11:2.0.0"
+    compile "org.scalikejdbc:scalikejdbc-jsr310_2.11:2.3.3"
+    compile "org.skinny-framework:skinny-orm_2.11:2.0.3"
     compile "org.springframework.boot:spring-boot-starter-actuator"
     compile "org.springframework.boot:spring-boot-starter-security"
     compile "org.springframework.boot:spring-boot-starter-aop"
@@ -47,14 +47,14 @@ dependencies {
     compile "net.sf.ehcache:ehcache-core:2.6.+"
     compile "commons-io:commons-io:2.4"
     compile "org.apache.commons:commons-lang3:3.3.+"
-    compile "com.ibm.icu:icu4j:54.1.+"
+    compile "com.ibm.icu:icu4j:56.1"
     compile fileTree(dir: 'libs', includes: ['*.jar'])
     runtime "com.h2database:h2:1.4.+"
-    testCompile "org.scalikejdbc:scalikejdbc-test_2.11:2.2.+"
+    testCompile "org.scalikejdbc:scalikejdbc-test_2.11:2.3.+"
     testCompile "org.scalatest:scalatest_2.11:2.2.+"
     testCompile "org.springframework.boot:spring-boot-starter-test"
 }
 
 task wrapper(type: Wrapper) {
-  gradleVersion = "2.9"
+  gradleVersion = "2.10"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip


### PR DESCRIPTION
- Spring Boot 1.3.0 to 1.3.1
- Skinny ORM 2.0.0 to 2.0.3
- Gradle 2.9 to 2.10
